### PR TITLE
fixed button behavior on hover

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -59,6 +59,8 @@ html[data-theme] .whiteCat  {
   top: -15px;
   width: 100%;
   opacity: 0.1;
+
+  z-index: -1;
 }
 
 .fakeTerminal {


### PR DESCRIPTION
Due to the transparent background of the button "Get Started", half of the button above the image was inactive. I fixed this with the assignment 
z-index for the picture. The button works correctly now.